### PR TITLE
Fix default for OS version format change

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ It should work with any point release within Ansible 2.6 major release, and ther
 
 Vagrant version ```2.2.4``` was used during the development & testing of Amazon Linux 2 revision of the role.
 
+This role contains jinja template actions that are only compatiable with jinja2 >= 2.8. Unfortunately Amazon Linux 2 (and upstream) only ship with 2.7. Python 2 is EOL and el7 is sunsetting, there will not be an updated rpm for this. Therefore, getting this role to run succesfully will require something you really shouldn't do - update a Python package installed by RPM using pip. 
+
+You bend it you fix it, ```sudo pip install -U jinja2``` will bring jinja up to a compatiable version.
+
 Testing
 -------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,7 +21,7 @@ cis_level_2_exclusions: []
 fail_on_manual_remediation_actions: false  # True or false.
 
 cis_target_os_distribution: "Amazon"
-cis_target_os_versions: [ "(Karoo)" ]
+cis_target_os_versions: [ "(Karoo)", "2" ]
 
 cis_modprobe_conf_filename: "/etc/modprobe.d/CIS.conf"
 cis_grub_bootloader_filename: "/boot/grub2/grub.cfg"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,6 +8,6 @@ galaxy_info:
   min_ansible_version: 2.5
   platforms:
   - name: Amazon
-    versions: [ "(Karoo)" ]
+    versions: [ "(Karoo)", "2"]
   galaxy_tags: ['CIS','Linux','Amazon','hardening','benchmark','PCIDSS','compliance']
 dependencies: []


### PR DESCRIPTION
AL2 has changed the version naming so that it no longer has Karoo in the version. Default updated to cover this.

Also added notes to readme to cover ansible install issues.